### PR TITLE
Change Namespacing Scheme to Match Cocoa Conventions

### DIFF
--- a/Example/SSOperationsExample/SSViewController.m
+++ b/Example/SSOperationsExample/SSViewController.m
@@ -23,17 +23,17 @@
  
     self.view.backgroundColor = [UIColor whiteColor];
     
-    serialQueue = [NSOperationQueue SSSerialOperationQueue];
-    concurrentQueue = [NSOperationQueue SSConcurrentMaxOperationQueue];
+    serialQueue = [NSOperationQueue ss_serialOperationQueue];
+    concurrentQueue = [NSOperationQueue ss_concurrentMaxOperationQueue];
 	
     // Run some operations!
     for( NSUInteger i = 0; i < 10; i++ ) {
-        [serialQueue SSAddBlockOperationWithBlock:^(SSBlockOperation *operation) {
+        [serialQueue ss_addBlockOperationWithBlock:^(SSBlockOperation *operation) {
             for( NSUInteger j = 0; j < 100; j++ )
                 NSLog(@"Serial #%i: %i", i, j);
         }];
         
-        [concurrentQueue SSAddBlockOperationWithBlock:^(SSBlockOperation *operation) {
+        [concurrentQueue ss_addBlockOperationWithBlock:^(SSBlockOperation *operation) {
             for( NSUInteger j = 0; j < 100; j++ )
                 NSLog(@"Concurrent #%i: %i", i, j);
         }];

--- a/SSOperations/NSOperationQueue+SSAdditions.h
+++ b/SSOperations/NSOperationQueue+SSAdditions.h
@@ -16,24 +16,24 @@
 /**
  * Construct an NSOperationQueue that runs serially with a maximum of one concurrent operation.
  */
-+ (instancetype) SSSerialOperationQueue;
++ (instancetype) ss_serialOperationQueue;
 
 /**
  * Construct an NSOperationQueue that runs with the system-provided maximum number of
  * concurrent operations.
  */
-+ (instancetype) SSConcurrentMaxOperationQueue;
++ (instancetype) ss_concurrentMaxOperationQueue;
 
 /**
  * Construct an NSOperationQueue with the specified number of concurrent operations.
  */
-+ (instancetype) SSConcurrentQueueWithConcurrentOperations:(NSUInteger)operationCount;
++ (instancetype) ss_concurrentQueueWithConcurrentOperations:(NSUInteger)operationCount;
 
 #pragma mark - Operations
 
 /**
  * Enqueue an `SSBlockOperation` with the specified operation block.
  */
-- (void) SSAddBlockOperationWithBlock:(SSBlockOperationBlock)block;
+- (void) ss_addBlockOperationWithBlock:(SSBlockOperationBlock)block;
 
 @end

--- a/SSOperations/NSOperationQueue+SSAdditions.m
+++ b/SSOperations/NSOperationQueue+SSAdditions.m
@@ -10,22 +10,22 @@
 
 @implementation NSOperationQueue (SSAdditions)
 
-+ (instancetype) SSSerialOperationQueue {
-    return [self SSConcurrentQueueWithConcurrentOperations:1];
++ (instancetype) ss_serialOperationQueue {
+    return [self ss_concurrentQueueWithConcurrentOperations:1];
 }
 
-+ (instancetype) SSConcurrentMaxOperationQueue {
-    return [self SSConcurrentQueueWithConcurrentOperations:NSOperationQueueDefaultMaxConcurrentOperationCount];
++ (instancetype) ss_concurrentMaxOperationQueue {
+    return [self ss_concurrentQueueWithConcurrentOperations:NSOperationQueueDefaultMaxConcurrentOperationCount];
 }
 
-+ (instancetype) SSConcurrentQueueWithConcurrentOperations:(NSUInteger)operationCount {
++ (instancetype) ss_concurrentQueueWithConcurrentOperations:(NSUInteger)operationCount {
     NSOperationQueue *queue = [NSOperationQueue new];
     [queue setMaxConcurrentOperationCount:operationCount];
     
     return queue;
 }
 
-- (void) SSAddBlockOperationWithBlock:(SSBlockOperationBlock)block {
+- (void) ss_addBlockOperationWithBlock:(SSBlockOperationBlock)block {
     [self addOperation:[SSBlockOperation operationWithBlock:block]];
 }
 


### PR DESCRIPTION
this is the way most other 3rd party categories do namespacing
