### PR TITLE
Allow NSOperationQueue subclasses

### DIFF
--- a/SSOperations/NSOperationQueue+SSAdditions.m
+++ b/SSOperations/NSOperationQueue+SSAdditions.m
@@ -43,7 +43,7 @@
 
 + (instancetype)ss_concurrentQueueWithConcurrentOperations:(NSUInteger)operationCount
                                                      named:(NSString *)name {
-    NSOperationQueue *queue = [NSOperationQueue new];
+    NSOperationQueue *queue = [self new];
     [queue setMaxConcurrentOperationCount:operationCount];
     [queue setName:name];
     


### PR DESCRIPTION
Currently, if you call any of the `NSOperationQueue` convenience initializers, they call `[NSOperationQueue new]`, which is not correct in the case of subclasses on `NSOperationQueue`. Instead, they should be calling `self`, which refers to the current class.

:100: :cool: :sunglasses: 
